### PR TITLE
[bot] 添加的赛事 3SCTF2024 待审核

### DIFF
--- a/CN.json
+++ b/CN.json
@@ -3,6 +3,17 @@
     "data": {
         "result": [
             {
+                "name": "3SCTF2024",
+                "link": "https://github.com/ProbiusOfficial/Hello-CTFtime/issues/new?assignees=ProbiusOfficial&labels=&projects=&template=add-eventInfo.yml&title=%3C%E6%B7%BB%E5%8A%A0%E6%AF%94%E8%B5%9B%3E",
+                "type": "个人赛",
+                "bmks": "2024年01月01日 00:00",
+                "bmjz": "2024年01月01日 00:00",
+                "bsks": "2024年01月01日 00:00",
+                "bsjs": "2024年01月01日 00:00",
+                "readmore": "readmore QQ群：590430891 引导你大致的了解CTF，并且尝试教会你如何入门CTF",
+                "status": 0
+            },
+            {
                 "name": "第一届“长城杯”信息安全铁人三项赛初赛",
                 "link": "http://ccb.itsec.gov.cn/",
                 "type": "团队赛|1-4人",


### PR DESCRIPTION
请审查提交的赛事信息：

### 赛事名称

3SCTF2024

### 比赛链接

https://github.com/ProbiusOfficial/Hello-CTFtime/issues/new?assignees=ProbiusOfficial&labels=&projects=&template=add-eventInfo.yml&title=%3C%E6%B7%BB%E5%8A%A0%E6%AF%94%E8%B5%9B%3E

### 比赛类型

个人赛

### 报名开始时间

2024年01月01日 00:00

### 报名结束时间

2024年01月01日 00:00

### 比赛开始时间

2024年01月01日 00:00

### 比赛结束时间

2024年01月01日 00:00

### 备注信息

备注信息 QQ群：590430891 引导你大致的了解CTF，并且尝试教会你如何入门CTF

### 比赛状态

0 - 报名未开始